### PR TITLE
Update to version 24.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "stable",
     "require": {
         "guzzlehttp/guzzle": "^6.5 || ^7.0",
-        "facebook/php-business-sdk": "^23.0.3"
+        "facebook/php-business-sdk": "^24.0.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
SO-80002 — bump `facebook/php-business-sdk` constraint from `^23.0.3` → `^24.0.1`.

Mirrors PR #7 (the v23 update). One-line composer.json change, no code changes.

Pairs with meetsoci/facebook-php-business-sdk#9. Sequence the tagging: SDK fork's `24.0.1.72` first, then this repo's `24.0.1.72`, so `^24.0.1` resolves to the .72 (PHP-7-compat) tag rather than falling back to the bare upstream-mirror tag.